### PR TITLE
fix: send data from mime structure instead of empty formpost

### DIFF
--- a/lib/VtComments.c
+++ b/lib/VtComments.c
@@ -159,7 +159,6 @@ int VtComments_add(struct VtComments *vt_comments, const char *comment) {
   CURLcode res;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
-  struct curl_httppost *formpost=NULL;
   int ret = 0;
   struct curl_slist *headerlist=NULL;
   static const char header_buf[] = "Expect:";
@@ -220,7 +219,7 @@ int VtComments_add(struct VtComments *vt_comments, const char *comment) {
 #endif
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* enable verbose for easier tracing */
   if (debug_level)

--- a/lib/VtDebug.c
+++ b/lib/VtDebug.c
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "vtcapi_common.h"
 
-int debug_level = 1;
+int debug_level = 0;
 
 void VtDebug_setDebugLevel(int level) {
   debug_level = level;

--- a/lib/VtDebug.c
+++ b/lib/VtDebug.c
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "vtcapi_common.h"
 
-int debug_level = 0;
+int debug_level = 1;
 
 void VtDebug_setDebugLevel(int level) {
   debug_level = level;

--- a/lib/VtFile.c
+++ b/lib/VtFile.c
@@ -269,7 +269,6 @@ int VtFile_scan(struct VtFile *file_scan, const char *file_path, const char *not
   CURL *curl = NULL;
   CURLcode res;
   int ret = 0;
-  struct curl_httppost *formpost = NULL;
   struct curl_slist *headerlist = NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -334,7 +333,7 @@ int VtFile_scan(struct VtFile *file_scan, const char *file_path, const char *not
   curl_easy_setopt(curl, CURLOPT_URL, VT_API_BASE_URL "file/scan");
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   set_std_curl_data(file_scan, curl);
 
@@ -388,7 +387,6 @@ int VtFile_scanMemBuf(struct VtFile *file_scan, const char *filename,  const uns
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
   int ret = 0;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   static const char header_buf[] = "Expect:";
   long http_response_code = 0;
@@ -447,7 +445,7 @@ int VtFile_scanMemBuf(struct VtFile *file_scan, const char *filename,  const uns
   curl_easy_setopt(curl, CURLOPT_URL, VT_API_BASE_URL "file/scan");
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   set_std_curl_data(file_scan, curl);
 
@@ -501,7 +499,6 @@ int VtFile_rescanHash(struct VtFile *file_scan,
   CURL *curl = NULL;
   CURLcode res;
   int ret = 0;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -613,7 +610,7 @@ int VtFile_rescanHash(struct VtFile *file_scan,
   curl_easy_setopt(curl, CURLOPT_URL, VT_API_BASE_URL "file/rescan");
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   set_std_curl_data(file_scan, curl);
 
@@ -664,7 +661,6 @@ int VtFile_rescanDelete(struct VtFile *file_scan,
   CURL *curl = NULL;
   CURLcode res;
   int ret = 0;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -711,7 +707,7 @@ int VtFile_rescanDelete(struct VtFile *file_scan,
   set_std_curl_data(file_scan, curl);
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Perform the request, res will get the return code */
   res = curl_easy_perform(curl);
@@ -760,7 +756,6 @@ int VtFile_report(struct VtFile *file_scan, const char *hash) {
   CURL *curl = NULL;
   CURLcode res;
   int ret = 0;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -804,8 +799,7 @@ int VtFile_report(struct VtFile *file_scan, const char *hash) {
   curl_easy_setopt(curl, CURLOPT_URL, VT_API_BASE_URL "file/report");
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
-
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
   set_std_curl_data(file_scan, curl);
 
   /* Perform the request, res will get the return code */
@@ -856,7 +850,6 @@ int VtFile_search(struct VtFile *file_scan, const char *query,
   CURLcode res;
   int ret = 0;
   json_t *resp_json = NULL;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -917,7 +910,7 @@ int VtFile_search(struct VtFile *file_scan, const char *query,
   set_std_curl_data(file_scan, curl);
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* Perform the request, res will get the return code */
   res = curl_easy_perform(curl);
@@ -1260,7 +1253,6 @@ int VtFile_scanBigFile(struct VtFile *file_scan, const char * path) {
   int ret;
   CURL *curl = NULL;
   CURLcode res;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -1309,7 +1301,7 @@ int VtFile_scanBigFile(struct VtFile *file_scan, const char * path) {
   curl_easy_setopt(curl, CURLOPT_URL, url);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L); // download API will redirect to link
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
   set_std_curl_data(file_scan, curl);
 
 

--- a/lib/VtUrl.c
+++ b/lib/VtUrl.c
@@ -138,7 +138,6 @@ int VtUrl_scan(struct VtUrl *vt_url, const char *url) {
   CURL *curl = NULL;
   CURLcode res;
   int ret = 0;
-  struct curl_httppost *formpost=NULL;
   struct curl_slist *headerlist=NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -185,7 +184,7 @@ int VtUrl_scan(struct VtUrl *vt_url, const char *url) {
 #endif
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* enable verbose for easier tracing */
   if (debug_level)
@@ -235,7 +234,6 @@ int VtUrl_report(struct VtUrl *vt_url, const char *resource, bool scan, bool all
   CURL *curl = NULL;
   CURLcode res;
   int ret = 0;
-  struct curl_httppost *formpost = NULL;
   struct curl_slist *headerlist = NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part = NULL;
@@ -302,7 +300,7 @@ int VtUrl_report(struct VtUrl *vt_url, const char *resource, bool scan, bool all
 #endif
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
-  curl_easy_setopt(curl, CURLOPT_MIMEPOST, formpost); // set form
+  curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
 
   /* enable verbose for easier tracing */
   if (debug_level)


### PR DESCRIPTION
We tried to pass an empty `formpost` handle to `CURLOPT_MIMEPOST`, which should normally pass a mime handle previously obtained from `curl_mime_init`. Unfortunately, this led to an empty POST request being sent:

```
* Connected to www.virustotal.com (74.125.34.46) port 443 (#0)
c-vtapi<1>:xferinfo:176: UP: 0 of 0  DOWN: 0 of 0
progress_callback 0/0
* ALPN, offering h2
* ALPN, offering http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
c-vtapi<1>:xferinfo:176: UP: 0 of 0  DOWN: 0 of 0
progress_callback 0/0
c-vtapi<1>:xferinfo:176: UP: 0 of 0  DOWN: 0 of 0
progress_callback 0/0
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=ES; L=Malaga; O=VirusTotal SL; CN=*.virustotal.com
*  start date: Dec 12 00:00:00 2022 GMT
*  expire date: Jan 12 23:59:59 2024 GMT
*  subjectAltName: host "www.virustotal.com" matched cert's "*.virustotal.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS RSA SHA256 2020 CA1
*  SSL certificate verify ok.
c-vtapi<1>:xferinfo:176: UP: 0 of 0  DOWN: 0 of 0
progress_callback 0/0
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55c7b380b110)
> POST /vtapi/v2/file/scan HTTP/2
Host: www.virustotal.com
accept: */*
content-length: 0
```
Without this fix, libcurl will attempt to send empty POST requests to the API, where the content length is set to 0.